### PR TITLE
chore: Fix runtime wallaby error

### DIFF
--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -12,7 +12,6 @@ module.exports = wallaby => ({
   tests: ['index.spec.js', 'src/**/*.spec.js', '!node_modules/**'],
   env: {
     type: 'node',
-    runner: 'node',
     NODE_ENV: 'test',
   },
 


### PR DESCRIPTION
Remove runner as this causes issues when using `asdf`